### PR TITLE
fix bug: options -audioBitrate and -audioSamplerate for CocoaSplitCmd has been disabled.

### DIFF
--- a/CocoaSplit/CaptureController.h
+++ b/CocoaSplit/CaptureController.h
@@ -179,11 +179,9 @@ void VideoCompressorReceiveFrame(void *, void *, OSStatus , VTEncodeInfoFlags , 
 @property (assign) int captureHeight;
 @property (assign) int captureWidth;
 
-@property (assign) int audioBitrate;
 
 @property (strong) NSArray *validSamplerates;
 
-@property (assign) int audioSamplerate;
 
 
 - (IBAction)removeDestination:(id)sender;

--- a/CocoaSplit/CaptureController.m
+++ b/CocoaSplit/CaptureController.m
@@ -1013,12 +1013,12 @@
     
     if ([cmdargs objectForKey:@"audioBitrate"])
     {
-        self.audioBitrate = [cmdargs integerForKey:@"audioBitrate"];
+        self.audioCaptureSession.audioBitrate = [cmdargs integerForKey:@"audioBitrate"];
     }
     
     if ([cmdargs objectForKey:@"audioSamplerate"])
     {
-        self.audioSamplerate = [cmdargs integerForKey:@"audioSamplerate"];
+        self.audioCaptureSession.audioSamplerate = [cmdargs integerForKey:@"audioSamplerate"];
     }
     
     if ([cmdargs objectForKey:@"x264tune"])


### PR DESCRIPTION
CocoaSplitCmd has a bug that stops with error while launching it.
The cause is that options -audioBitrate and -audioSamplerate has no effect and audioBitrate and audioSamplerate are set to zero (default value).
This patch fixes it.
